### PR TITLE
Allowing `fromAddr` specify utxos from specific address

### DIFF
--- a/types/custom-types.d.ts
+++ b/types/custom-types.d.ts
@@ -77,6 +77,7 @@ export type WalletSave = {
 
 export interface TxSend {
   toAddr: string;
+  fromAddr: string|undefined;
   amount: number;
   fee: number;
   //tx?: kaspacore.Transaction;

--- a/wallet/utxo.ts
+++ b/wallet/utxo.ts
@@ -200,9 +200,10 @@ export class UtxoSet extends EventTargetImpl {
 	/**
 	 * Naively select UTXOs.
 	 * @param txAmount Provide the amount that the UTXOs should cover.
+	 * @param fromAddr Select UTXOs only from this address
 	 * @throws Error message if the UTXOs can't cover the `txAmount`
 	 */
-	selectUtxos(txAmount: number): {
+	selectUtxos(txAmount: number, fromAddr?: string): {
 		utxoIds: string[];
 		utxos: UnspentOutput[],
 		mass: number
@@ -213,7 +214,7 @@ export class UtxoSet extends EventTargetImpl {
 		let list = [...this.utxos.confirmed.values()];
 
 		list = list.filter((utxo) => {
-			return !this.inUse.includes(utxo.id);
+			return !this.inUse.includes(utxo.id) && (!fromAddr || utxo.address.toString() === fromAddr);
 		});
 
 		list.sort((a: UnspentOutput, b: UnspentOutput): number => {
@@ -243,8 +244,9 @@ export class UtxoSet extends EventTargetImpl {
 	/**
 	 * Naively collect UTXOs.
 	 * @param maxCount Provide the max UTXOs count.
+	 * @param fromAddr collect UTXOs only from this address
 	 */
-	collectUtxos(maxCount: number = 10000): {
+	collectUtxos(maxCount: number = 10000, fromAddr?: string): {
 		utxoIds: string[];
 		utxos: UnspentOutput[],
 		amount: number,
@@ -256,7 +258,7 @@ export class UtxoSet extends EventTargetImpl {
 		let list = [...this.utxos.confirmed.values()];
 
 		list = list.filter((utxo) => {
-			return !this.inUse.includes(utxo.id);
+			return !this.inUse.includes(utxo.id) && (!fromAddr || utxo.address.toString() === fromAddr);
 		});
 
 		list.sort((a: UnspentOutput, b: UnspentOutput): number => {

--- a/wallet/wallet.ts
+++ b/wallet/wallet.ts
@@ -765,6 +765,7 @@ class Wallet extends EventTargetImpl {
 	 */
 	composeTx({
 		toAddr,
+		fromAddr,
 		amount,
 		fee = DEFAULT_FEE,
 		changeAddrOverride,
@@ -783,9 +784,9 @@ class Wallet extends EventTargetImpl {
 		//if (!Number.isSafeInteger(amount)) throw new Error(`Amount ${amount} is too large`);
 		let utxos, utxoIds, mass;
 		if(compoundingUTXO){
-			({utxos, utxoIds, amount, mass} = this.utxoSet.collectUtxos(compoundingUTXOMaxCount));
+			({utxos, utxoIds, amount, mass} = this.utxoSet.collectUtxos(compoundingUTXOMaxCount, fromAddr));
 		}else{
-			({utxos, utxoIds, mass} = this.utxoSet.selectUtxos(amount + fee));
+			({utxos, utxoIds, mass} = this.utxoSet.selectUtxos(amount + fee, fromAddr));
 		}
 		//if(mass > Wallet.MaxMassUTXOs){
 		//	throw new Error(`Maximum number of inputs (UTXOs) reached. Please reduce this transaction amount.`);
@@ -1164,6 +1165,7 @@ class Wallet extends EventTargetImpl {
 
 		let txParamsArg = {
 			toAddr,
+			fromAddr: undefined,
 			changeAddrOverride:toAddr,
 			amount: -1,
 			fee,


### PR DESCRIPTION
I am using this library in a side project, and I needed to control transaction submission by addresses.
I suggest adding `fromAddr` to transaction input.

**Point of discussion**: Should I allow specifying only a single address, or maybe it is better to allow array input for choosing a subset of arrays?